### PR TITLE
Merge useful changes by Andrzej Pieńkowski

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # EDUtest chatcommands
 
+This fork introduces the following changes:
+- `student` privilege disabled to make all non-teacher users 'students' by default
+- `teacher` privilege changed to `instructor` to avoid conflict with Sfan5's `teaching` mod
+- added chat command `heal <subject>` to help classes work in enable_damage=on environments
+- added chat command `announce <message>` which displays message in a custom formspec
+
 The goal of the EDUtest project is to facilitate the usage of Minetest
 in an educational context.
 
@@ -7,9 +13,9 @@ This mod provides chatcommands for the educational staff.
 
 ## setup
 
-The commands expect the students to be marked with the "student" privilege,
+The commands expect ~~the students to be marked with the "student" privilege~~,
 while the teacher(s) are marked with the "teacher" privilege.
 
-A common way to set this up would be to add "student" to the default_privs
+~~A common way to set this up would be to add "student" to the default_privs
 server configuration option, and to revoke it manually from the teacher(s),
-while granting them the "teacher" privilege.
+while granting them the "teacher" privilege.~~


### PR DESCRIPTION
I'd like to discuss merging these changes into the initial EDUtest codebase since a common, compatible codebase should benefit all users, and the changes seem to be fit well into the usage scenarios I know of. In particular:

* "teacher" privilege renaming: It was controversial anyway since not all education-related contexts are school-based.

* "student" privilege removal: It's not needed anyway since in the usual education-related scenarios, everyone who is not a "teacher" will be a "student". Furthermore, future versions will support bulk commands on "student" groups, which cannot be implemented well using privileges.

* "heal" and "announce" commands: Seem generally useful.

-------------------------------------------------------------------------

Ich wuerde gerne eine Diskussion anstossen, ob diese Aenderungen in die urspruengliche EDUtest-Code-Basis aufgenommen werden sollten. Ich denke, es spricht einiges dafuer, da eine gemeinsame, kompatible Code-Basis allen Nutzern zugutekommen duerfte, und da die Aenderungen dort, wo EDUtest meines Wissens genutzt wird, meines Erachtens gut hineinpassen.

* Umbenennung des "teacher"-Privilegs: Die Bezeichnung war ohnehin kontrovers, da nicht jeder paedagogische Kontext mit Schulen zusammenhaengt.

* Entfernung des "student"-Privilegs: Es ist ohnehin nicht notwendig, da ueblicherweise jeder, der nicht "teacher" ist, "student" ist. Darueber hinaus wird in der Zukunft Unterstuetzung fuer Massenkommandos auf Schuelergruppen implementiert, was ohnehin nicht gut mit Privilegien umzusetzen ist.

* Kommandos "heal" und "announce": Scheinen mir allgemein nuetzlich zu sein.