### PR TITLE
require teacher priv for visitation chat command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2013,6 +2013,7 @@ minetest.register_chatcommand(
             "reversibly teleport self or other players"
         ),
         privs = {
+            teacher = true,
         },
         func = function(
             own_name,


### PR DESCRIPTION
The visitation command is a full teleport command and I would suggest that is should be require the teacher privilege.
Otherwise students can teleport to each other without asking for permission and can also teleport to coordinates of their choice, which can be used for "breaking" into another player's buildings. 